### PR TITLE
Apple compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ Or by running scripts only:
 - Clone project and init submodules
 - Generate and build project using **cmake**
 
+### MacOS (aarch64)
+- Install **VulkanSDK**
+- Setup environment variables using `setup-env.sh` from VulkanSDK (e.x. `source ~/VulkanSDK/1.3.283.0/setup-env.sh`)
+- Clone project and init submodules
+- Generate and build project using **cmake**
+
+Or by running scripts only:
+- Run `./1-Deploy.sh`
+- Run `./2-Build.sh`
+
 ### CMake options
 `-DUSE_MINIMAL_DATA=ON` - download minimal resource package (90MB)
 

--- a/Source/Clear.cpp
+++ b/Source/Clear.cpp
@@ -181,7 +181,7 @@ void Sample::RenderFrame(uint32_t frameIndex)
             NRI.CmdClearAttachments(commandBuffer, &clearDesc, 1, &rect2, 1);
 
             clearDesc.value.color32f = {0.0f, 0.0f, 1.0f, 1.0f};
-            nri::Rect rect3 = { 0, y * 2, w, h3 };
+            nri::Rect rect3 = { 0, (int16_t)(y * 2), w, h3 };
             NRI.CmdClearAttachments(commandBuffer, &clearDesc, 1, &rect3, 1);
         }
         NRI.CmdEndRendering(commandBuffer);

--- a/Source/DeviceInfo.cpp
+++ b/Source/DeviceInfo.cpp
@@ -1,7 +1,7 @@
 // © 2021 NVIDIA Corporation
 
 #include <stdio.h>
-#include <malloc.h>
+#include <stdlib.h>
 
 #define NRI_FORCE_C
 

--- a/Source/Readback.cpp
+++ b/Source/Readback.cpp
@@ -273,7 +273,7 @@ void Sample::RenderFrame(uint32_t frameIndex)
             NRI.CmdClearAttachments(commandBuffer, &clearDesc, 1, &rect2, 1);
 
             clearDesc.value.color32f = {0.0f, 0.0f, 1.0f, 1.0f};
-            nri::Rect rect3 = { 0, y * 2, w, h3 };
+            nri::Rect rect3 = { 0, (int16_t)(y * 2), w, h3 };
             NRI.CmdClearAttachments(commandBuffer, &clearDesc, 1, &rect3, 1);
 
             RenderUI(NRI, NRI, *m_Streamer, commandBuffer, 1.0f, true);

--- a/Source/Wrapper.cpp
+++ b/Source/Wrapper.cpp
@@ -13,6 +13,9 @@
 
     #define VK_USE_PLATFORM_WIN32_KHR 1
     const char* VULKAN_LOADER_NAME = "vulkan-1.dll";
+#elif __APPLE__
+    #define VK_USE_PLATFORM_METAL_EXT 1
+    const char* VULKAN_LOADER_NAME = "libvulkan.dylib";
 #else
     #define VK_USE_PLATFORM_XLIB_KHR 1
     const char* VULKAN_LOADER_NAME = "libvulkan.so";
@@ -227,6 +230,8 @@ void Sample::CreateVulkanDevice()
 
 #ifdef _WIN32
     const char* instanceExtensions[] = { VK_KHR_WIN32_SURFACE_EXTENSION_NAME, VK_KHR_SURFACE_EXTENSION_NAME };
+#elif __APPLE__
+    const char* instanceExtensions[] = { VK_EXT_METAL_SURFACE_EXTENSION_NAME };
 #else
     const char* instanceExtensions[] = { VK_KHR_XLIB_SURFACE_EXTENSION_NAME };
 #endif
@@ -778,7 +783,7 @@ void Sample::RenderFrame(uint32_t frameIndex)
         FreeLibrary((HMODULE)&library);
     }
 
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__APPLE__)
 
     #include <dlfcn.h>
 


### PR DESCRIPTION
- Updated MacOS build instructions
- Added an explicit cast to `int16_t` for `Readback` and `Clear` samples (MacOS CLang is required the explicit cast)
- Provided MacOs specific loader and extensions in Wrapper
- Replaced `malloc.h` with `stdlib.h` (POSIX-compatible systems defines malloc in stdlib.h)