### PR TITLE
feat: modififcations to compile on macosx

### DIFF
--- a/Source/Clear.cpp
+++ b/Source/Clear.cpp
@@ -173,7 +173,7 @@ void Sample::RenderFrame(uint32_t frameIndex) {
             NRI.CmdClearAttachments(commandBuffer, &clearDesc, 1, &rect2, 1);
 
             clearDesc.value.color.f = {0.0f, 0.0f, 1.0f, 1.0f};
-            nri::Rect rect3 = {0, y * 2, w, h3};
+            nri::Rect rect3 = {0, static_cast<int16_t>(y * 2), w, h3};
             NRI.CmdClearAttachments(commandBuffer, &clearDesc, 1, &rect3, 1);
         }
         NRI.CmdEndRendering(commandBuffer);

--- a/Source/DeviceInfo.cpp
+++ b/Source/DeviceInfo.cpp
@@ -1,6 +1,5 @@
 // © 2021 NVIDIA Corporation
 
-#include <malloc.h>
 #include <stdio.h>
 
 #define NRI_FORCE_C

--- a/Source/Readback.cpp
+++ b/Source/Readback.cpp
@@ -259,7 +259,7 @@ void Sample::RenderFrame(uint32_t frameIndex) {
             NRI.CmdClearAttachments(commandBuffer, &clearDesc, 1, &rect2, 1);
 
             clearDesc.value.color.f = {0.0f, 0.0f, 1.0f, 1.0f};
-            nri::Rect rect3 = {0, y * 2, w, h3};
+            nri::Rect rect3 = {0, static_cast<int16_t>(y * 2), w, h3};
             NRI.CmdClearAttachments(commandBuffer, &clearDesc, 1, &rect3, 1);
 
             RenderUI(NRI, NRI, *m_Streamer, commandBuffer, 1.0f, true);

--- a/Source/Wrapper.cpp
+++ b/Source/Wrapper.cpp
@@ -13,6 +13,9 @@
 
 #    define VK_USE_PLATFORM_WIN32_KHR 1
 const char* VULKAN_LOADER_NAME = "vulkan-1.dll";
+#elif defined(__APPLE__)
+#define VK_USE_PLATFORM_METAL_EXT
+const char* VULKAN_LOADER_NAME = "libvulkan.dynlib";
 #else
 #    define VK_USE_PLATFORM_XLIB_KHR 1
 const char* VULKAN_LOADER_NAME = "libvulkan.so";
@@ -211,6 +214,8 @@ void Sample::CreateVulkanDevice() {
 
 #ifdef _WIN32
     const char* instanceExtensions[] = {VK_KHR_WIN32_SURFACE_EXTENSION_NAME, VK_KHR_SURFACE_EXTENSION_NAME};
+#elif defined(__APPLE__)
+    const char* instanceExtensions[] = {VK_EXT_METAL_SURFACE_EXTENSION_NAME};
 #else
     const char* instanceExtensions[] = {VK_KHR_XLIB_SURFACE_EXTENSION_NAME};
 #endif
@@ -738,8 +743,8 @@ void Sample::RenderFrame(uint32_t frameIndex) {
 
 #ifdef _WIN32
 
-#    include <windows.h>
-#    undef LoadLibrary
+#include <windows.h>
+#undef LoadLibrary
 
 Library* LoadSharedLibrary(const char* path) {
     return (Library*)LoadLibraryA(path);
@@ -753,9 +758,9 @@ void UnloadSharedLibrary(Library& library) {
     FreeLibrary((HMODULE)&library);
 }
 
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__APPLE__)
 
-#    include <dlfcn.h>
+#include <dlfcn.h>
 
 Library* LoadSharedLibrary(const char* path) {
     return (Library*)dlopen(path, RTLD_NOW);


### PR DESCRIPTION
made a couple modification to be able to compile on my macbook. seems like I'm unable to run any of the samples though. 


```
michaelpollind@MichaelPollind-58 NRISamples % ./_Bin/Debug/Triangle 
Creating borderless window (1512, 982)
Loading...
WARNING-CreateInstance-status-message(INFO / SPEC): msgNum: 601872502 - Validation Information: [ WARNING-CreateInstance-status-message ] Object 0: handle = 0x128072a00, type = VK_OBJECT_TYPE_INSTANCE; | MessageID = 0x23dfd876 | vkCreateInstance():  Khronos Validation Layer Active:
    Settings File: Found at /Users/michaelpollind/.local/share/vulkan/settings.d/vk_layer_settings.txt specified by VkConfig application override.
    Current Enables: None.
    Current Disables: VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT, VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT.

    Objects: 1
        [0] 0x128072a00, type: 1, name: NULL
VUID-VkPhysicalDeviceGroupProperties-sType-sType(ERROR / SPEC): msgNum: -907153781 - Validation Error: [ VUID-VkPhysicalDeviceGroupProperties-sType-sType ] | MessageID = 0xc9edee8b | vkEnumeratePhysicalDeviceGroups(): pPhysicalDeviceGroupProperties[0].sType must be VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES. The Vulkan spec states: sType must be VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES (https://vulkan.lunarg.com/doc/view/1.3.290.0/mac/1.3-extensions/vkspec.html#VUID-VkPhysicalDeviceGroupProperties-sType-sType)
    Objects: 0
nri::INFO (DeviceVK.hpp:133) - VK::Unknown - Supported instance extensions:
nri::INFO (DeviceVK.hpp:135) - VK::Unknown -     VK_KHR_device_group_creation (v1)
nri::INFO (DeviceVK.hpp:135) - VK::Unknown -     VK_KHR_external_fence_capabilities (v1)
nri::INFO (DeviceVK.hpp:135) - VK::Unknown -     VK_KHR_external_memory_capabilities (v1)
nri::INFO (DeviceVK.hpp:135) - VK::Unknown -     VK_KHR_external_semaphore_capabilities (v1)
nri::INFO (DeviceVK.hpp:135) - VK::Unknown -     VK_KHR_get_physical_device_properties2 (v2)
nri::INFO (DeviceVK.hpp:135) - VK::Unknown -     VK_KHR_get_surface_capabilities2 (v1)
nri::INFO (DeviceVK.hpp:135) - VK::Unknown -     VK_KHR_surface (v25)
nri::INFO (DeviceVK.hpp:135) - VK::Unknown -     VK_EXT_debug_report (v10)
nri::INFO (DeviceVK.hpp:135) - VK::Unknown -     VK_EXT_debug_utils (v2)
nri::INFO (DeviceVK.hpp:135) - VK::Unknown -     VK_EXT_headless_surface (v1)
nri::INFO (DeviceVK.hpp:135) - VK::Unknown -     VK_EXT_layer_settings (v2)
nri::INFO (DeviceVK.hpp:135) - VK::Unknown -     VK_EXT_metal_surface (v1)
nri::INFO (DeviceVK.hpp:135) - VK::Unknown -     VK_EXT_surface_maintenance1 (v1)
nri::INFO (DeviceVK.hpp:135) - VK::Unknown -     VK_EXT_swapchain_colorspace (v4)
nri::INFO (DeviceVK.hpp:135) - VK::Unknown -     VK_MVK_macos_surface (v3)
nri::INFO (DeviceVK.hpp:135) - VK::Unknown -     VK_KHR_portability_enumeration (v1)
nri::INFO (DeviceVK.hpp:135) - VK::Unknown -     VK_LUNARG_direct_driver_loading (v1)
nri::INFO (DeviceVK.hpp:135) - VK::Unknown -     VK_EXT_validation_features (v2)
WARNING-CreateInstance-status-message(INFO / SPEC): msgNum: 601872502 - Validation Information: [ WARNING-CreateInstance-status-message ] Object 0: handle = 0x12806f408, type = VK_OBJECT_TYPE_INSTANCE; | MessageID = 0x23dfd876 | vkCreateInstance():  Khronos Validation Layer Active:
    Settings File: Found at /Users/michaelpollind/.local/share/vulkan/settings.d/vk_layer_settings.txt specified by VkConfig application override.
    Current Enables: None.
    Current Disables: VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT, VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT.

    Objects: 1
        [0] 0x12806f408, type: 1, name: NULL
VUID-VkPhysicalDeviceGroupProperties-sType-sType(ERROR / SPEC): msgNum: -907153781 - Validation Error: [ VUID-VkPhysicalDeviceGroupProperties-sType-sType ] | MessageID = 0xc9edee8b | vkEnumeratePhysicalDeviceGroups(): pPhysicalDeviceGroupProperties[0].sType must be VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES. The Vulkan spec states: sType must be VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES (https://vulkan.lunarg.com/doc/view/1.3.290.0/mac/1.3-extensions/vkspec.html#VUID-VkPhysicalDeviceGroupProperties-sType-sType)
    Objects: 0
nri::INFO (DeviceVK.hpp:179) - VK::Apple M3 - Supported device extensions:
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_16bit_storage (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_8bit_storage (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_bind_memory2 (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_buffer_device_address (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_calibrated_timestamps (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_copy_commands2 (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_create_renderpass2 (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_dedicated_allocation (v3)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_deferred_host_operations (v4)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_depth_stencil_resolve (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_descriptor_update_template (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_device_group (v4)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_driver_properties (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_dynamic_rendering (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_external_fence (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_external_memory (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_external_semaphore (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_fragment_shader_barycentric (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_format_feature_flags2 (v2)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_get_memory_requirements2 (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_imageless_framebuffer (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_image_format_list (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_incremental_present (v2)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_maintenance1 (v2)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_maintenance2 (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_maintenance3 (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_map_memory2 (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_multiview (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_portability_subset (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_push_descriptor (v2)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_relaxed_block_layout (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_sampler_mirror_clamp_to_edge (v3)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_sampler_ycbcr_conversion (v14)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_separate_depth_stencil_layouts (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_shader_draw_parameters (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_shader_float_controls (v4)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_shader_float16_int8 (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_shader_integer_dot_product (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_shader_non_semantic_info (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_shader_subgroup_extended_types (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_spirv_1_4 (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_storage_buffer_storage_class (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_swapchain (v70)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_swapchain_mutable_format (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_synchronization2 (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_timeline_semaphore (v2)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_uniform_buffer_standard_layout (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_variable_pointers (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_KHR_vertex_attribute_divisor (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_EXT_4444_formats (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_EXT_buffer_device_address (v2)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_EXT_calibrated_timestamps (v2)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_EXT_debug_marker (v4)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_EXT_descriptor_indexing (v2)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_EXT_extended_dynamic_state (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_EXT_extended_dynamic_state2 (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_EXT_extended_dynamic_state3 (v2)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_EXT_external_memory_host (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_EXT_fragment_shader_interlock (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_EXT_hdr_metadata (v2)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_EXT_host_image_copy (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_EXT_host_query_reset (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_EXT_image_robustness (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_EXT_inline_uniform_block (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_EXT_memory_budget (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_EXT_metal_objects (v2)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_EXT_pipeline_creation_cache_control (v3)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_EXT_pipeline_creation_feedback (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_EXT_post_depth_coverage (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_EXT_private_data (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_EXT_robustness2 (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_EXT_sample_locations (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_EXT_scalar_block_layout (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_EXT_separate_stencil_usage (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_EXT_shader_atomic_float (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_EXT_shader_demote_to_helper_invocation (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_EXT_shader_stencil_export (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_EXT_shader_subgroup_ballot (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_EXT_shader_subgroup_vote (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_EXT_shader_viewport_index_layer (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_EXT_subgroup_size_control (v2)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_EXT_swapchain_maintenance1 (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_EXT_texel_buffer_alignment (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_EXT_texture_compression_astc_hdr (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_EXT_vertex_attribute_divisor (v3)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_AMD_gpu_shader_half_float (v2)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_AMD_negative_viewport_height (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_AMD_shader_image_load_store_lod (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_AMD_shader_trinary_minmax (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_IMG_format_pvrtc (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_INTEL_shader_integer_functions2 (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_GOOGLE_display_timing (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_NV_fragment_shader_barycentric (v1)
nri::INFO (DeviceVK.hpp:181) - VK::Apple M3 -     VK_NV_glsl_shader (v1)
nri::ERROR (DeviceVK.hpp:1577) - VK::Apple M3 - ResolveDispatchTable(): Failed to get device function: 'vkGetDeviceBufferMemoryRequirements'
zsh: trace trap  ./_Bin/Debug/Triangle
michaelpollind@MichaelPollind-58 NRISamples % 
```

ref: https://github.com/NVIDIAGameWorks/NRI/issues/105

